### PR TITLE
My Blocks +: Allow editing global block from outside defining sprite.

### DIFF
--- a/extension-code/My-Blocks-Plus.js
+++ b/extension-code/My-Blocks-Plus.js
@@ -734,9 +734,13 @@ V1.2
         if (block.type === "procedures_call") {
           const isGlobal = globalBlocksCache[block.procCode_];
           if (isGlobal && isGlobal.id !== vm.editingTarget.id) {
-            alert("Global Blocks can only be editted in their Sprite of Origin");
             vm.setEditingTarget(isGlobal.id);
-            return;
+            window.setTimeout(function() {
+              const blockId = vm.editingTarget.blocks.getProcedureDefinition(block.procCode_)
+              block = SB.mainWorkspace.getBlockById(blockId);
+              return procs.editProcedureCallback_.call(this, block);
+            }, 600); // > 300 was needed in testing. Using 600 to be safe.
+            return;            
           }
         }
         const sharedWork = SB.mainWorkspace;


### PR DESCRIPTION
Instead of showing an alert when you try to edit a block from a different sprite, the extension can just automatically call edit again after switching to the right target.

I wish I could use something less heavy-handed them an arbitrary setTimeout() but it seems to work!